### PR TITLE
Replace import with direct class in `framework.isobot.currency`

### DIFF
--- a/isobot/currency.py
+++ b/isobot/currency.py
@@ -1,6 +1,12 @@
 import json
 import discord
-from colors import Colors
+
+class Colors():
+    """Contains general stdout colors."""
+    cyan = '\033[96m'
+    red = '\033[91m'
+    green = '\033[92m'
+    end = '\033[0m'
 
 class CurrencyAPI(Colors):
     """The isobot API used for managing currency.


### PR DESCRIPTION
It was observed in https://github.com/PyBotDevs/isobot-lazer/pull/103 that importing the currency module from the framework would cause an import error due to the colours library. So I replaced the import with a direct class which actually lets the framework run properly.